### PR TITLE
Entity 생성 - 진경석

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/blog/domain/blog/domain/Blog.java
+++ b/src/main/java/com/example/blog/domain/blog/domain/Blog.java
@@ -14,10 +14,10 @@ public class Blog {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 30, nullable = false)
+    @Column(name = "name", length = 30, nullable = false)
     private String name;
 
-    @Column(length = 60, nullable = false)
+    @Column(name = "blogurl", length = 60, nullable = false)
     private String blogUrl;
 
     @Builder

--- a/src/main/java/com/example/blog/domain/blog/domain/Blog.java
+++ b/src/main/java/com/example/blog/domain/blog/domain/Blog.java
@@ -1,6 +1,7 @@
 package com.example.blog.domain.blog.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,10 +15,12 @@ public class Blog {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name", length = 30, nullable = false)
+    @Column(name = "name", length = 30)
+    @NotNull
     private String name;
 
-    @Column(name = "blogurl", length = 60, nullable = false)
+    @Column(name = "blogurl", length = 60)
+    @NotNull
     private String blogUrl;
 
     @Builder

--- a/src/main/java/com/example/blog/domain/blog/domain/Blog.java
+++ b/src/main/java/com/example/blog/domain/blog/domain/Blog.java
@@ -1,0 +1,32 @@
+package com.example.blog.domain.blog.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Blog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 30, nullable = false)
+    private String name;
+
+    @Column(length = 60, nullable = false)
+    private String blogUrl;
+
+    @Builder
+    public Blog(String name, String blogUrl) {
+        this.name = name;
+        this.blogUrl = blogUrl;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/blog/domain/board/domain/Board.java
+++ b/src/main/java/com/example/blog/domain/board/domain/Board.java
@@ -28,7 +28,7 @@ public class Board extends BaseTimeEntity {
     private String title;
 
     @Column(name = "content", length = 1024)
-    @ColumnDefault("")
+    @ColumnDefault("''")
     private String content;
 
     @Column(name = "createdAt", updatable = false)
@@ -41,9 +41,9 @@ public class Board extends BaseTimeEntity {
     @NotNull
     private LocalDateTime updatedAt;
 
-    @Column(name = "view")
+    @Column(name = "view_count")
     @ColumnDefault("0")
-    private int view;
+    private int viewCount;
 
     @Builder
     public Board (String title, String content) {
@@ -60,6 +60,6 @@ public class Board extends BaseTimeEntity {
     }
 
     public void increaseView() {
-        this.view++;
+        this.viewCount++;
     }
 }

--- a/src/main/java/com/example/blog/domain/board/domain/Board.java
+++ b/src/main/java/com/example/blog/domain/board/domain/Board.java
@@ -2,6 +2,7 @@ package com.example.blog.domain.board.domain;
 
 import com.example.blog.util.BaseTimeEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,19 +23,22 @@ public class Board extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "title", length = 30, nullable = false)
+    @Column(name = "title", length = 30)
+    @NotNull
     private String title;
 
     @Column(name = "content", length = 1024)
     @ColumnDefault("")
     private String content;
 
-    @Column(name = "createdAt", nullable = false, updatable = false)
+    @Column(name = "createdAt", updatable = false)
     @CreatedDate
+    @NotNull
     private LocalDateTime createdAt;
 
-    @Column(name = "updatedAt", nullable = false)
+    @Column(name = "updatedAt")
     @LastModifiedDate
+    @NotNull
     private LocalDateTime updatedAt;
 
     @Column(name = "view")

--- a/src/main/java/com/example/blog/domain/board/domain/Board.java
+++ b/src/main/java/com/example/blog/domain/board/domain/Board.java
@@ -1,0 +1,59 @@
+package com.example.blog.domain.board.domain;
+
+import com.example.blog.util.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Board extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", length = 30, nullable = false)
+    private String title;
+
+    @Column(name = "content", length = 1024)
+    @ColumnDefault("")
+    private String content;
+
+    @Column(name = "createdAt", nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name = "updatedAt", nullable = false)
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Column(name = "view")
+    @ColumnDefault("0")
+    private int view;
+
+    @Builder
+    public Board (String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void increaseView() {
+        this.view++;
+    }
+}

--- a/src/main/java/com/example/blog/domain/board/domain/Board.java
+++ b/src/main/java/com/example/blog/domain/board/domain/Board.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Board extends BaseTimeEntity {
     @Id

--- a/src/main/java/com/example/blog/domain/category/domain/Category.java
+++ b/src/main/java/com/example/blog/domain/category/domain/Category.java
@@ -1,0 +1,21 @@
+package com.example.blog.domain.category.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", length = 10, nullable = false)
+    private String name;
+
+    void updateName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/blog/domain/category/domain/Category.java
+++ b/src/main/java/com/example/blog/domain/category/domain/Category.java
@@ -1,6 +1,7 @@
 package com.example.blog.domain.category.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,7 +13,8 @@ public class Category {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name", length = 10, nullable = false)
+    @Column(name = "name", length = 10)
+    @NotNull
     private String name;
 
     void updateName(String name) {

--- a/src/main/java/com/example/blog/domain/comment/domain/Comment.java
+++ b/src/main/java/com/example/blog/domain/comment/domain/Comment.java
@@ -2,6 +2,7 @@ package com.example.blog.domain.comment.domain;
 
 import com.example.blog.util.BaseTimeEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,15 +20,18 @@ public class Comment extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "content", length = 300,  nullable = false)
+    @Column(name = "content", length = 300)
+    @NotNull
     private String content;
 
-    @Column(name = "createdAt", nullable = false, updatable = false)
+    @Column(name = "createdAt")
     @CreatedDate
+    @NotNull
     private LocalDateTime createdAt;
 
-    @Column(name = "updatedAt", nullable = false)
+    @Column(name = "updatedAt")
     @LastModifiedDate
+    @NotNull
     private LocalDateTime updatedAt;
 
     @Builder

--- a/src/main/java/com/example/blog/domain/comment/domain/Comment.java
+++ b/src/main/java/com/example/blog/domain/comment/domain/Comment.java
@@ -1,0 +1,37 @@
+package com.example.blog.domain.comment.domain;
+
+import com.example.blog.util.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "content", length = 300)
+    private String content;
+
+    @Column(name = "createdAt", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updatedAt", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Comment(String content) {
+        this.content = content;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/example/blog/domain/comment/domain/Comment.java
+++ b/src/main/java/com/example/blog/domain/comment/domain/Comment.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
@@ -17,13 +19,15 @@ public class Comment extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "content", length = 300)
+    @Column(name = "content", length = 300,  nullable = false)
     private String content;
 
     @Column(name = "createdAt", nullable = false, updatable = false)
+    @CreatedDate
     private LocalDateTime createdAt;
 
     @Column(name = "updatedAt", nullable = false)
+    @LastModifiedDate
     private LocalDateTime updatedAt;
 
     @Builder

--- a/src/main/java/com/example/blog/domain/file/domain/File.java
+++ b/src/main/java/com/example/blog/domain/file/domain/File.java
@@ -1,0 +1,36 @@
+package com.example.blog.domain.file.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class File {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 30)
+    private String name;
+
+    @Column(name = "storageUrl", nullable = false, length = 100)
+    private String storageUrl;
+
+    @Builder
+    public File(String name, String storageUrl) {
+        this.name = name;
+        this.storageUrl = storageUrl;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateStorageUrl(String storageUrl) {
+        this.storageUrl = storageUrl;
+    }
+
+}

--- a/src/main/java/com/example/blog/domain/file/domain/File.java
+++ b/src/main/java/com/example/blog/domain/file/domain/File.java
@@ -1,6 +1,7 @@
 package com.example.blog.domain.file.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,10 +14,12 @@ public class File {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name", nullable = false, length = 30)
+    @Column(name = "name", length = 30)
+    @NotNull
     private String name;
 
-    @Column(name = "storageUrl", nullable = false, length = 100)
+    @Column(name = "storageUrl", length = 100)
+    @NotNull
     private String storageUrl;
 
     @Builder

--- a/src/main/java/com/example/blog/domain/like/domain/Like.java
+++ b/src/main/java/com/example/blog/domain/like/domain/Like.java
@@ -4,9 +4,12 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
 @Entity
 @Getter
+@DynamicInsert
 @NoArgsConstructor
 public class Like {
     @Id
@@ -14,6 +17,7 @@ public class Like {
     private Long id;
 
     @Column(name = "count")
+    @ColumnDefault("0")
     private Long count;
 
     // 좋아요 클릭

--- a/src/main/java/com/example/blog/domain/like/domain/Like.java
+++ b/src/main/java/com/example/blog/domain/like/domain/Like.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.DynamicInsert;
 @Getter
 @DynamicInsert
 @NoArgsConstructor
+@Table(name = "likes")
 public class Like {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/blog/domain/like/domain/Like.java
+++ b/src/main/java/com/example/blog/domain/like/domain/Like.java
@@ -1,0 +1,28 @@
+package com.example.blog.domain.like.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Like {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "count")
+    private Long count;
+
+    // 좋아요 클릭
+    public void clickLike() {
+        this.count++;
+    }
+    
+    // 좋아요 취소
+    public void cancelLike() {
+        this.count--;
+    }
+}

--- a/src/main/java/com/example/blog/domain/user/domain/User.java
+++ b/src/main/java/com/example/blog/domain/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.example.blog.domain.user.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,16 +17,20 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "email", length = 50, nullable = false)
+    @Column(name = "email", length = 50)
+    @NotNull
     private String email;
 
-    @Column(name = "password", length = 25, nullable = false)
+    @Column(name = "password", length = 25)
+    @NotNull
     private String password;
 
-    @Column(name = "nickname", length = 25, nullable = false)
+    @Column(name = "nickname", length = 25)
+    @NotNull
     private String nickname;
 
-    @Column(name = "birthdate", nullable = false)
+    @Column(name = "birthdate")
+    @NotNull
     private LocalDate birthdate;
 
     // 빌더 패턴

--- a/src/main/java/com/example/blog/domain/user/domain/User.java
+++ b/src/main/java/com/example/blog/domain/user/domain/User.java
@@ -6,26 +6,42 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class User{
+public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String username;
+
+    @Column(name = "email", length = 50, nullable = false)
+    private String email;
+
+    @Column(name = "password", length = 25, nullable = false)
     private String password;
+
+    @Column(name = "nickname", length = 25, nullable = false)
+    private String nickname;
+
+    @Column(name = "birthdate", nullable = false)
+    private LocalDate birthdate;
 
     // 빌더 패턴
     @Builder
-    public User(String username, String password) {
-        this.username = username;
+    public User(String email, String password, String nickname, LocalDate birthdate) {
+        this.email = email;
         this.password = password;
+        this.nickname = nickname;
+        this.birthdate = birthdate;
     }
 
     //편의 메서드
-    public void update(String username, String password) {
-        this.username=username;
+    public void updatePassword(String password) {
         this.password = password;
+    }
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/example/blog/util/BaseTimeEntity.java
+++ b/src/main/java/com/example/blog/util/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package com.example.blog.util;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 1. 내가 개발한 기능
* 생성, 수정 시간 관리를 위한 BaseTimeEntity 구현
* 연관 관계를 제외한 나머지 필드에 대한 일부 편의 메서드 구현
* @Column의  nullable 속성보다 @NotNull이 쿼리를 DB에 전송하기 전 예외에 대해서 알 수 있어서 더 좋다는 걸 알게 되어 해당 부분을 수정.


## 2. 내가 개발할 때 유의깊게 개발한 부분
* 생성, 수정 시간을 공통적으로 관리하기 위해서 BaseTimeEntity를 구현.
* DB의 Not Null 제약조건을 위배하지 않기 위해서 @Colunm의 nullable = false 사용.
* 조회수, 게시글 내용 등에 대해서 기본값 지정이 필요한 경우 @ColumnDefault 사용. 
     * @ColumnDefault만 사용할 경우, DDL에서 적용이 되는 것이고 실제로 Insert를 수행할 때는 적용이 되지 않아서 오류가 발생 할 수 있음을 알게 되었습니다.
     * 해결 방안으로는 @PrePersist와 @DynamicInsert를 사용하는 것이 있었고, @DynamicInsert를 사용하였습니다.
     * @PrePersist의 경우 Insert 전에 개발자가 직접 설정한 값으로 처리하여 default값을 설정하는 방식이었고, @DynamicInsert는 null인 값은 Insert에 포함시키지 않기 때문에 직접적으로 멤버 변수를 처리하는 것보다 낫다고 생각되었기 때문입니다.
* 이외에 편의 메서드를 구현할 때, 최대한 간결하게 작성하려고 함.
* 어노테이션에 대한 개념(?)이 부족한 것 같아서, 다양하게 사용하기보다는 기본적으로 자주 사용하는 어노테이션에 대해서 발생할 수 있는 문제등을 유의하면서 개발.


## 3. 내가 개발하면서 들었던 의문 사항
 1. 어노테이션을 적절히 잘 사용하고 있는가? (굳이? 이걸 사용하는가? 싶은 어노테이션을 사용했는지)
 2. @PrePersist, @DynamicInsert 중 어떤 것을 사용하는게 더 적절한지? (제가 찾아볼때는 개인 취향같은 느낌이 강했습니다..)
 3. 편의 메서드를 구현하면서 이런 메서드가 있는 것이 맞는가? 고민을 하면서 구현했던 것 같습니다.
 4. 어노테이션(@NotNull, @Column 등등)을 대부분의 필드에서 사용해서 그런지 이렇게 해도 되는가 하는 의문이 들긴했습니다.


## 4. 내가 설계한 ERD (ERD Cloud)
![image](https://github.com/Likelion-YeungNam-Univ/12th-be-jpa1-assignment/assets/115134208/2038dc27-8c9c-4828-8329-545cd02ff574)
피드백을 반영했고, 이번 과제를 진행하면서 부족하다(?)고 생각되는 부분이나 어색한 부분에 대해서는 수정을 했습니다.
